### PR TITLE
Now explicitly using Dates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 StringEncodings
 Missings
+Dates

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 StringEncodings
 Missings
-Dates
+Compat 0.37.0

--- a/src/SASLib.jl
+++ b/src/SASLib.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module SASLib
 
-using StringEncodings, Missings
+using StringEncodings, Missings, Dates
 
 export readsas, REGULAR_STR_ARRAY
 

--- a/src/SASLib.jl
+++ b/src/SASLib.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module SASLib
 
-using StringEncodings, Missings, Dates
+using StringEncodings, Missings, Compat.Dates
 
 export readsas, REGULAR_STR_ARRAY
 


### PR DESCRIPTION
The package was not compiling for me (on Julia v0.7) because it was trying to implicitly use Dates. I added Dates to the REQUIRE and imported all of its functions via `using Dates`, and the package compile errors went away.

Dates is part of the `stdlib`, so it shouldn't be an issue depending on it, although maybe there are better ways to import its functions than what I've done here.