### PR TITLE
Type Widening

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 StringEncodings
 Missings
+Dates

--- a/src/SASLib.jl
+++ b/src/SASLib.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module SASLib
 
-using StringEncodings, Missings
+using StringEncodings, Missings, Dates
 
 export readsas, REGULAR_STR_ARRAY
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,7 @@
 Strip from the right end of the `bytes` array for any byte that matches the ones
 specified in the `remove` argument.  See Python's bytes.rstrip function.
 """
-function brstrip(bytes::Vector{UInt8}, remove::Vector{UInt8})
+function brstrip(bytes::AbstractVector{UInt8}, remove::AbstractVector{UInt8})
     for i in length(bytes):-1:1
         x = bytes[i]
         found = false
@@ -36,7 +36,7 @@ end
 """
 Find needle in the haystack with both `Vector{UInt8}` type arguments.
 """
-function Base.contains(haystack::Vector{UInt8}, needle::Vector{UInt8})
+function Base.contains(haystack::AbstractVector{UInt8}, needle::AbstractVector{UInt8})
     hlen = length(haystack)
     nlen = length(needle)
     if hlen >= nlen


### PR DESCRIPTION
Functions like `contains` and `brstrip` had `Vector{UInt8}` as inputs, but on Julia v0.7, this needs to be `AbstractVector{UInt8}` because byte array literals return something called `CodeUnits` now. This should not impact functionality on Julia v0.6.2.