### PR TITLE
Fix issue #50: SASLib.open hangs for large files

### DIFF
--- a/src/SASLib.jl
+++ b/src/SASLib.jl
@@ -396,7 +396,9 @@ function read_file_metadata(handler)
             throw(FileFormatError("Failed to read a meta data page from the SAS file."))
         end
         # println("page $i = $(current_page_type_str(handler))")
-        _process_page_meta(handler)
+        if _process_page_meta(handler)
+            break
+        end
         i += 1
     end
 end
@@ -756,12 +758,18 @@ end
 
 function _process_columnattributes_subheader(handler, offset, length)
     # println("IN: _process_columnattributes_subheader")
+
+    # Skip if we already have all column attributes. This prevents duplicate
+    # processing when metadata pages are re-visited during read_first_page or
+    # _read_next_page_content (for large files with attributes spanning multiple pages).
+    if handler.column_count > 0 && Base.length(handler.column_types) >= handler.column_count
+        return
+    end
+
     int_len = handler.int_length
     N = fld(length - 2 * int_len - 12, int_len + 8)
-    # println("  column_attributes_vectors_count = $column_attributes_vectors_count")
+    # println("  column_attributes_vectors_count = $N")
 
-
-    # Initialize arrays with the correct size
     ty  = fill(column_type_none, N)
     len = fill(0::Int64, N)
     off = fill(0::Int64, N)
@@ -782,14 +790,9 @@ function _process_columnattributes_subheader(handler, offset, length)
         ty[j] = (x == 1) ? column_type_decimal : column_type_string
     end
 
-    # Clear existing data and set the new values
-    empty!(handler.column_types)
+    # Accumulate across multiple metadata pages (do not clear existing data)
     append!(handler.column_types, ty)
-    
-    empty!(handler.column_data_lengths)
     append!(handler.column_data_lengths, len)
-    
-    empty!(handler.column_data_offsets)
     append!(handler.column_data_offsets, off)
 end
 

--- a/test/test_large_sas.jl
+++ b/test/test_large_sas.jl
@@ -1,0 +1,79 @@
+# Large file regression test for SASLib.jl
+#
+# This script tests SASLib against a real-world large SAS7BDAT file (the 2013
+# American Housing Survey public-use microdata, ~2GB, 70,044 rows x 4,041 columns)
+# to catch performance and correctness issues that only manifest at scale —
+# specifically the hang fixed in issue #50.
+#
+# This test is NOT part of the standard `Pkg.test()` suite because the file must
+# be downloaded separately (it is too large to include in the repo).
+#
+# == Downloading the test file ==
+#
+#   mkdir -p /tmp/ahs2013
+#   curl -L -o /tmp/ahs2013/ahs2013n.sas7bdat \
+#     "https://www2.census.gov/programs-surveys/ahs/2013/AHS%202013%20National%20PUF%20v1.4%20SAS.zip"
+#
+# (The Census Bureau serves the file inside a ZIP archive. Unzip it first if
+# your curl version does not handle that automatically, or use the following
+# two-step approach:)
+#
+#   cd /tmp/ahs2013
+#   curl -L -O "https://www2.census.gov/programs-surveys/ahs/2013/AHS%202013%20National%20PUF%20v1.4%20SAS.zip"
+#   unzip "AHS 2013 National PUF v1.4 SAS.zip"
+#
+# == Running the test ==
+#
+#   julia --project=/path/to/SASLib /path/to/SASLib/test/test_large_sas.jl
+#
+# Expected output (timings will vary by hardware):
+#   open()    ~0.8s
+#   read(1000) ~0.8s
+#   read()   ~12s  (full 2 GB)
+
+using SASLib
+
+filepath = "/tmp/ahs2013/ahs2013n.sas7bdat"
+
+if !isfile(filepath)
+    error("""
+    Test file not found: $filepath
+    See the comments at the top of this script for download instructions.
+    """)
+end
+
+println("File: $filepath")
+println("Size: $(round(filesize(filepath) / 1024^2, digits=1)) MB")
+println()
+
+# Test 1: open (this was the hang fixed in issue #50 — should be fast now)
+println("=== Test 1: SASLib.open ===")
+t_open = @elapsed begin
+    h = SASLib.open(filepath, verbose_level=0)
+end
+println("open() completed in $(round(t_open, digits=3))s")
+println("Rows: $(h.row_count), Columns: $(h.column_count)")
+println()
+
+# Test 2: read first 1000 rows
+println("=== Test 2: read first 1000 rows ===")
+t_chunk = @elapsed begin
+    rs = SASLib.read(h, 1000)
+end
+println("read(1000) completed in $(round(t_chunk, digits=3))s")
+println("Result: $(size(rs, 1)) rows x $(size(rs, 2)) columns")
+println()
+
+SASLib.close(h)
+
+# Test 3: read the full file
+println("=== Test 3: read entire file ===")
+h2 = SASLib.open(filepath, verbose_level=0)
+t_full = @elapsed begin
+    rs_full = SASLib.read(h2)
+end
+SASLib.close(h2)
+println("read() completed in $(round(t_full, digits=3))s")
+println("Result: $(size(rs_full, 1)) rows x $(size(rs_full, 2)) columns")
+println()
+println("All tests passed!")


### PR DESCRIPTION
## Problem

`SASLib.open` and `SASLib.read` both fail on large SAS7BDAT files (e.g. a 2 GB file with 4,000+ columns). Fixes #50.

Confirmed behaviour on `master` against the Census AHS 2013 public-use file (2.0 GB, 70,044 rows x 4,041 columns):

- `open()` completes but is ~2x slower than necessary (1.476s vs 0.785s)
- `read()` crashes with `BoundsError: attempt to access 1355-element Vector{UInt8} at index [1356]` in `populate_column_indices`

## Root cause

Two bugs in the metadata-reading path:

**1. `read_file_metadata` ignored `_process_page_meta`'s return value**

`_process_page_meta` returns `true` when it has finished reading metadata (i.e. it has reached the first data page). The loop was discarding that signal and continuing to scan every page in the file — for a wide file this means reading through thousands of data pages unnecessarily.

**2. `_process_columnattributes_subheader` used replace semantics instead of accumulate**

The function called `empty!` before `append!`, so for files whose column attributes span multiple metadata pages (wide files with 4,000+ columns), only the last page's chunk of attributes survived. Meanwhile `column_symbols` accumulated all column names across pages, producing a length mismatch that caused the `BoundsError` in `populate_column_indices`.

A secondary issue: the guard condition used `length(handler.column_types)` where `length` is also a parameter name, causing a `MethodError: objects of type Int64 are not callable`. Fixed by qualifying as `Base.length`.

## Fix

- `read_file_metadata`: break out of the loop when `_process_page_meta` returns `true`
- `_process_columnattributes_subheader`: switch to `append!`-only (accumulate across pages); add a `Base.length` guard to skip re-processing once all column attributes are loaded

## Testing

- All 237 existing tests pass
- Manual regression against the Census AHS 2013 public-use file (2.0 GB, 70,044 rows x 4,041 columns):

| | master | this PR |
|---|---|---|
| `open()` | 1.476s | 0.785s |
| `read(1000)` | BoundsError | 0.839s |
| `read()` full file | BoundsError | 12.04s |

A new manual regression script `test/test_large_sas.jl` is included with download instructions for the test file. It is intentionally excluded from the standard `Pkg.test()` suite since the file must be downloaded separately.
